### PR TITLE
fix: Reject unknown attributes and/or relationships

### DIFF
--- a/.changeset/heavy-crabs-provide.md
+++ b/.changeset/heavy-crabs-provide.md
@@ -1,0 +1,5 @@
+---
+"jsonapi-fastify": patch
+---
+
+fix: attribute and relationship schema should be strict

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/node_modules
 # Jest code coverage
 coverage
+
+.DS_Store

--- a/lib/src/schemas/schema.ts
+++ b/lib/src/schemas/schema.ts
@@ -402,13 +402,13 @@ export function resourceFromDef(
         isResponse || opts?.update
           ? // responses and update requests are loosely validated -- just ensure the right types
             // are being returned for the attribute (if provided).
-            attributes.partial().optional()
+            attributes.partial().strict().optional()
           : hasAttributes
           ? // create operations require the entire attribute object as declared.
-            attributes
+            attributes.strict()
           : // if the schema does not define any required attributes, allow clients to omit
             // the attributes property entirely.
-            attributes.optional(),
+            attributes.strict().optional(),
       // ****************************
       // Some notes on relationships:
       // ****************************
@@ -416,11 +416,11 @@ export function resourceFromDef(
         isResponse || opts?.update
           ? // responses and update requests are loosely validated -- just ensure the right types
             // are being returned for the relationship (if provided).
-            relationships.partial().optional()
+            relationships.partial().strict().optional()
           : // relationships are optional in create requests; if the client does not provide
             // them, their default values should be assumed per JSON:API spec.
             // (null for to-one, empty array for to-many).
-            relationships.optional()
+            relationships.strict().optional()
     }),
     {
       description: def.description

--- a/lib/src/tests/create.test.ts
+++ b/lib/src/tests/create.test.ts
@@ -330,4 +330,30 @@ describe('when creating resources', () => {
     const body = JSON.parse(response.body);
     expect(body.errors[0].source.pointer).toBe('/data/attributes/lastname');
   });
+
+  it('rejects unknown attributes', async () => {
+    const app = build();
+    const url = '/people';
+    const response = await app.inject({
+      method: 'POST',
+      url,
+      headers: {
+        'content-type': MEDIA_TYPE,
+        accept: MEDIA_TYPE
+      },
+      payload: {
+        data: {
+          type: 'people',
+          attributes: {
+            firstname: 'Jonah',
+            lastname: 'Jameson',
+            someAttribute: 42
+          }
+        }
+      }
+    });
+    expect(response.statusCode).toBe(422);
+    const body = JSON.parse(response.body);
+    expect(body.errors[0].source.pointer).toBe('/data/attributes');
+  });
 });


### PR DESCRIPTION
## Description

- fix: Validator no longer allows unknown attributes or relationships on client requests
- chore: Updates .gitignore